### PR TITLE
chore(deps): fix react deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "cf-release": "cd misc/cloudflare-workers && wrangler deploy"
   },
   "dependencies": {
-    "@hiogawa/react-server": "0.2.0",
+    "@hiogawa/react-server": "0.2.1",
     "react": "19.0.0-rc-8f3c0525f9-20240521",
     "react-dom": "19.0.0-rc-8f3c0525f9-20240521",
     "react-server-dom-webpack": "19.0.0-rc-8f3c0525f9-20240521"

--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
   },
   "dependencies": {
     "@hiogawa/react-server": "0.2.0",
-    "react": "19.0.0-beta-4508873393-20240430",
-    "react-dom": "19.0.0-beta-4508873393-20240430",
-    "react-server-dom-webpack": "19.0.0-beta-4508873393-20240430"
+    "react": "19.0.0-rc-8f3c0525f9-20240521",
+    "react-dom": "19.0.0-rc-8f3c0525f9-20240521",
+    "react-server-dom-webpack": "19.0.0-rc-8f3c0525f9-20240521"
   },
   "devDependencies": {
-    "@hattip/adapter-node": "^0.0.44",
     "@hiogawa/utils": "1.6.4-pre.2",
+    "@hiogawa/utils-node": "^0.0.1",
     "@hiogawa/vite-plugin-ssr-middleware": "0.0.3",
     "@types/react": "18.2.66",
     "@types/react-dom": "18.2.22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,24 +7,24 @@ settings:
 dependencies:
   '@hiogawa/react-server':
     specifier: 0.2.0
-    version: 0.2.0(react-dom@19.0.0-beta-4508873393-20240430)(react-server-dom-webpack@19.0.0-beta-4508873393-20240430)(react@19.0.0-beta-4508873393-20240430)(vite@5.2.10)
+    version: 0.2.0(react-dom@19.0.0-rc-8f3c0525f9-20240521)(react-server-dom-webpack@19.0.0-rc-8f3c0525f9-20240521)(react@19.0.0-rc-8f3c0525f9-20240521)(vite@5.2.10)
   react:
-    specifier: 19.0.0-beta-4508873393-20240430
-    version: 19.0.0-beta-4508873393-20240430
+    specifier: 19.0.0-rc-8f3c0525f9-20240521
+    version: 19.0.0-rc-8f3c0525f9-20240521
   react-dom:
-    specifier: 19.0.0-beta-4508873393-20240430
-    version: 19.0.0-beta-4508873393-20240430(react@19.0.0-beta-4508873393-20240430)
+    specifier: 19.0.0-rc-8f3c0525f9-20240521
+    version: 19.0.0-rc-8f3c0525f9-20240521(react@19.0.0-rc-8f3c0525f9-20240521)
   react-server-dom-webpack:
-    specifier: 19.0.0-beta-4508873393-20240430
-    version: 19.0.0-beta-4508873393-20240430(react-dom@19.0.0-beta-4508873393-20240430)(react@19.0.0-beta-4508873393-20240430)(webpack@5.91.0)
+    specifier: 19.0.0-rc-8f3c0525f9-20240521
+    version: 19.0.0-rc-8f3c0525f9-20240521(react-dom@19.0.0-rc-8f3c0525f9-20240521)(react@19.0.0-rc-8f3c0525f9-20240521)(webpack@5.91.0)
 
 devDependencies:
-  '@hattip/adapter-node':
-    specifier: ^0.0.44
-    version: 0.0.44
   '@hiogawa/utils':
     specifier: 1.6.4-pre.2
     version: 1.6.4-pre.2
+  '@hiogawa/utils-node':
+    specifier: ^0.0.1
+    version: 0.0.1
   '@hiogawa/vite-plugin-ssr-middleware':
     specifier: 0.0.3
     version: 0.0.3(vite@5.2.10)
@@ -744,42 +744,7 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
-  /@hattip/adapter-node@0.0.44:
-    resolution: {integrity: sha512-Qf0kcrE4yHFrmKgfntrxHGNkk0/9a45aKmAO3ex6OiRKat5DZCFDdFMHV85Z594IohzT7Q+WcWiHQl/b0Jvo7Q==}
-    dependencies:
-      '@hattip/core': 0.0.44
-      '@hattip/polyfills': 0.0.44
-      '@hattip/walk': 0.0.44
-    dev: true
-
-  /@hattip/core@0.0.44:
-    resolution: {integrity: sha512-hW0scygJk2FjC8lL+NAaV8eY5XtseXvX+EyORFgtURJQ33myy/epSFm7uLZcVNVU9aA0C4WyJQSza+U0rxt2Sg==}
-    dev: true
-
-  /@hattip/headers@0.0.44:
-    resolution: {integrity: sha512-bwNQ+o8RRTox9FWkmprTP8/rNki9BXkrthCDdnT5zgfkjZk6VFAloV5jmYqnqrNkh3Aw5DFGUcQJRoQBb4aQCw==}
-    dependencies:
-      '@hattip/core': 0.0.44
-    dev: true
-
-  /@hattip/polyfills@0.0.44:
-    resolution: {integrity: sha512-ldNES22u/135K8Yg6nti1djcwZeIw6e1SY/iqW0qh+AfyYNHuGTix7YL/9OKAD9wbOUj2NHqXYOGCT69NsfIqA==}
-    dependencies:
-      '@hattip/core': 0.0.44
-      '@whatwg-node/fetch': 0.9.17
-      node-fetch-native: 1.6.4
-    dev: true
-
-  /@hattip/walk@0.0.44:
-    resolution: {integrity: sha512-tjYO71byyQpdsOVKJ4cySAwWSYqU9IWbROiU1D9SqlQyEYN+TOEaB6n8YkX1gyRbLVkMe+/DJcuagm9AQdPO5A==}
-    hasBin: true
-    dependencies:
-      '@hattip/headers': 0.0.44
-      cac: 6.7.14
-      mime-types: 2.1.35
-    dev: true
-
-  /@hiogawa/react-server@0.2.0(react-dom@19.0.0-beta-4508873393-20240430)(react-server-dom-webpack@19.0.0-beta-4508873393-20240430)(react@19.0.0-beta-4508873393-20240430)(vite@5.2.10):
+  /@hiogawa/react-server@0.2.0(react-dom@19.0.0-rc-8f3c0525f9-20240521)(react-server-dom-webpack@19.0.0-rc-8f3c0525f9-20240521)(react@19.0.0-rc-8f3c0525f9-20240521)(vite@5.2.10):
     resolution: {integrity: sha512-bolFQwQLi8dsNU2MS/vNxmNPVPMQQHGrVCEh3APfxsPdltv8lH4YHAjv0WwPTsmqu/Jqhlw8LtlXyXP4j5VlWQ==}
     peerDependencies:
       react: 19.0.0-rc-8f3c0525f9-20240521
@@ -789,10 +754,10 @@ packages:
     dependencies:
       '@hiogawa/transforms': 0.0.0
       '@tanstack/history': 1.26.3
-      react: 19.0.0-beta-4508873393-20240430
-      react-dom: 19.0.0-beta-4508873393-20240430(react@19.0.0-beta-4508873393-20240430)
-      react-server-dom-webpack: 19.0.0-beta-4508873393-20240430(react-dom@19.0.0-beta-4508873393-20240430)(react@19.0.0-beta-4508873393-20240430)(webpack@5.91.0)
-      use-sync-external-store: 1.2.0(react@19.0.0-beta-4508873393-20240430)
+      react: 19.0.0-rc-8f3c0525f9-20240521
+      react-dom: 19.0.0-rc-8f3c0525f9-20240521(react@19.0.0-rc-8f3c0525f9-20240521)
+      react-server-dom-webpack: 19.0.0-rc-8f3c0525f9-20240521(react-dom@19.0.0-rc-8f3c0525f9-20240521)(react@19.0.0-rc-8f3c0525f9-20240521)(webpack@5.91.0)
+      use-sync-external-store: 1.2.0(react@19.0.0-rc-8f3c0525f9-20240521)
       vite: 5.2.10
     dev: false
 
@@ -803,6 +768,10 @@ packages:
       magic-string: 0.30.9
       periscopic: 4.0.2
     dev: false
+
+  /@hiogawa/utils-node@0.0.1:
+    resolution: {integrity: sha512-vEir6KhApTlPPT+0wX85wglFgZjxG/WZGjWGahSR7+ltNkpY0OpmxozbF5sLodYgXPObTK8cKgsQ4nzFLtZQ8g==}
+    dev: true
 
   /@hiogawa/utils@1.6.4-pre.2:
     resolution: {integrity: sha512-t49f46YPtqOBHWdceDX1PKK8dhIemFzNCFx2KtfCVUx0W4rZ4TtAyVAKbh7mJmLh/yITr3gNb0SxkfNyOZy0hQ==}
@@ -853,10 +822,6 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
-
-  /@kamilkisiela/fast-url-parser@1.1.4:
-    resolution: {integrity: sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==}
     dev: true
 
   /@rollup/rollup-android-arm-eabi@4.14.0:
@@ -1174,30 +1139,6 @@ packages:
       '@xtuc/long': 4.2.2
     dev: false
 
-  /@whatwg-node/events@0.1.1:
-    resolution: {integrity: sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==}
-    engines: {node: '>=16.0.0'}
-    dev: true
-
-  /@whatwg-node/fetch@0.9.17:
-    resolution: {integrity: sha512-TDYP3CpCrxwxpiNY0UMNf096H5Ihf67BK1iKGegQl5u9SlpEDYrvnV71gWBGJm+Xm31qOy8ATgma9rm8Pe7/5Q==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      '@whatwg-node/node-fetch': 0.5.10
-      urlpattern-polyfill: 10.0.0
-    dev: true
-
-  /@whatwg-node/node-fetch@0.5.10:
-    resolution: {integrity: sha512-KIAHepie/T1PRkUfze4t+bPlyvpxlWiXTPtcGlbIZ0vWkBJMdRmCg4ZrJ2y4XaO1eTPo1HlWYUuj1WvoIpumqg==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      '@kamilkisiela/fast-url-parser': 1.1.4
-      '@whatwg-node/events': 0.1.1
-      busboy: 1.6.0
-      fast-querystring: 1.1.2
-      tslib: 2.6.2
-    dev: true
-
   /@xtuc/ieee754@1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
     dev: false
@@ -1298,18 +1239,6 @@ packages:
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
     dev: false
-
-  /busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
-    dependencies:
-      streamsearch: 1.1.0
-    dev: true
-
-  /cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-    dev: true
 
   /caniuse-lite@1.0.30001606:
     resolution: {integrity: sha512-LPbwnW4vfpJId225pwjZJOgX1m9sGfbw/RKJvw/t0QhYOOaTXHvkjVGFGPpvwEzufrjvTlsULnVTxdy4/6cqkg==}
@@ -1529,10 +1458,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /fast-decode-uri-component@1.0.1:
-    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
-    dev: true
-
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: false
@@ -1540,12 +1465,6 @@ packages:
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
     dev: false
-
-  /fast-querystring@1.1.2:
-    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
-    dependencies:
-      fast-decode-uri-component: 1.0.1
-    dev: true
 
   /fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
@@ -1713,12 +1632,14 @@ packages:
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
+    dev: false
 
   /mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
+    dev: false
 
   /mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
@@ -1766,10 +1687,6 @@ packages:
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: false
-
-  /node-fetch-native@1.6.4:
-    resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
-    dev: true
 
   /node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
@@ -1837,13 +1754,13 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
-  /react-dom@19.0.0-beta-4508873393-20240430(react@19.0.0-beta-4508873393-20240430):
-    resolution: {integrity: sha512-/j97ai1qF3c6O3XV0nVzzExPV/0U2v8M75Sq6ThXYxePCi33kAnm+xRsCDpZOZOrIjz6nurLU/FzzPZIzXVvKQ==}
+  /react-dom@19.0.0-rc-8f3c0525f9-20240521(react@19.0.0-rc-8f3c0525f9-20240521):
+    resolution: {integrity: sha512-fLopgMEm6RQxfCXVoLKfGFcLJSqqxfFIDxznJCJsYUFrZIYLXTSJCwlSoCuU/LPHyweAoJh871l/9695jqnWaw==}
     peerDependencies:
-      react: 19.0.0-beta-4508873393-20240430
+      react: 19.0.0-rc-8f3c0525f9-20240521
     dependencies:
-      react: 19.0.0-beta-4508873393-20240430
-      scheduler: 0.25.0-beta-4508873393-20240430
+      react: 19.0.0-rc-8f3c0525f9-20240521
+      scheduler: 0.25.0-rc-8f3c0525f9-20240521
     dev: false
 
   /react-refresh@0.14.0:
@@ -1851,23 +1768,23 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-server-dom-webpack@19.0.0-beta-4508873393-20240430(react-dom@19.0.0-beta-4508873393-20240430)(react@19.0.0-beta-4508873393-20240430)(webpack@5.91.0):
-    resolution: {integrity: sha512-/rRIMqNoeReqyioWwfLyqu/qUfZ39YLXOfkhLrXOStzG2g7Q2a5DoLD0eZOcCIpvpWg+/QRw1xOGZLm75mK+Aw==}
+  /react-server-dom-webpack@19.0.0-rc-8f3c0525f9-20240521(react-dom@19.0.0-rc-8f3c0525f9-20240521)(react@19.0.0-rc-8f3c0525f9-20240521)(webpack@5.91.0):
+    resolution: {integrity: sha512-pzbj+T5d76qRCH8ynKhO37gXMKUfKuI3d+CqACzysaSlDhkv2b0Q+pqoPRf19S7zGrLsAaBHF2vHXnSdDtyg6Q==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      react: 19.0.0-beta-4508873393-20240430
-      react-dom: 19.0.0-beta-4508873393-20240430
+      react: 19.0.0-rc-8f3c0525f9-20240521
+      react-dom: 19.0.0-rc-8f3c0525f9-20240521
       webpack: ^5.59.0
     dependencies:
       acorn-loose: 8.4.0
       neo-async: 2.6.2
-      react: 19.0.0-beta-4508873393-20240430
-      react-dom: 19.0.0-beta-4508873393-20240430(react@19.0.0-beta-4508873393-20240430)
+      react: 19.0.0-rc-8f3c0525f9-20240521
+      react-dom: 19.0.0-rc-8f3c0525f9-20240521(react@19.0.0-rc-8f3c0525f9-20240521)
       webpack: 5.91.0(esbuild@0.20.2)
     dev: false
 
-  /react@19.0.0-beta-4508873393-20240430:
-    resolution: {integrity: sha512-//89udV7fhVq5pEzpNH7vlpmS5D4wDbPn0oif+G7vwDsuSks5yJGdqrE1uzn2CyFNL73FjV3/R3Pjyaxs+xnvg==}
+  /react@19.0.0-rc-8f3c0525f9-20240521:
+    resolution: {integrity: sha512-xZsfCREYO7jV4BXnUeLQaQq55FFQBw8alIL9JiexnbJEFq1Wl1TtOwoq00qIncNaDqBVqRNlPElGJgPq4WJoVA==}
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -1941,8 +1858,8 @@ packages:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
     dev: false
 
-  /scheduler@0.25.0-beta-4508873393-20240430:
-    resolution: {integrity: sha512-gk9vDoDOjTys0DpLgFll+hYk5gLhLnTipi81Pl+XSRtWkQnqQdjxLO2RF726t0g0jQ5tvwjLfBCgsvusgB6Luw==}
+  /scheduler@0.25.0-rc-8f3c0525f9-20240521:
+    resolution: {integrity: sha512-i27QJ0bghG46kJ1/XXTe69zPjRqKr9AO9tjRkqERkIof3wfsueI0IRYJqyS3ENWXnleG8ifBI63p7CsNAjEiVA==}
     dev: false
 
   /schema-utils@3.3.0:
@@ -2003,11 +1920,6 @@ packages:
   /stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
     engines: {node: '>=4', npm: '>=6'}
-    dev: true
-
-  /streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
     dev: true
 
   /supports-color@5.5.0:
@@ -2118,16 +2030,12 @@ packages:
       punycode: 2.3.1
     dev: false
 
-  /urlpattern-polyfill@10.0.0:
-    resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
-    dev: true
-
-  /use-sync-external-store@1.2.0(react@19.0.0-beta-4508873393-20240430):
+  /use-sync-external-store@1.2.0(react@19.0.0-rc-8f3c0525f9-20240521):
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      react: 19.0.0-beta-4508873393-20240430
+      react: 19.0.0-rc-8f3c0525f9-20240521
     dev: false
 
   /vite@5.2.10:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@hiogawa/react-server':
-    specifier: 0.2.0
-    version: 0.2.0(react-dom@19.0.0-rc-8f3c0525f9-20240521)(react-server-dom-webpack@19.0.0-rc-8f3c0525f9-20240521)(react@19.0.0-rc-8f3c0525f9-20240521)(vite@5.2.10)
+    specifier: 0.2.1
+    version: 0.2.1(react-dom@19.0.0-rc-8f3c0525f9-20240521)(react-server-dom-webpack@19.0.0-rc-8f3c0525f9-20240521)(react@19.0.0-rc-8f3c0525f9-20240521)(vite@5.2.10)
   react:
     specifier: 19.0.0-rc-8f3c0525f9-20240521
     version: 19.0.0-rc-8f3c0525f9-20240521
@@ -744,8 +744,8 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
-  /@hiogawa/react-server@0.2.0(react-dom@19.0.0-rc-8f3c0525f9-20240521)(react-server-dom-webpack@19.0.0-rc-8f3c0525f9-20240521)(react@19.0.0-rc-8f3c0525f9-20240521)(vite@5.2.10):
-    resolution: {integrity: sha512-bolFQwQLi8dsNU2MS/vNxmNPVPMQQHGrVCEh3APfxsPdltv8lH4YHAjv0WwPTsmqu/Jqhlw8LtlXyXP4j5VlWQ==}
+  /@hiogawa/react-server@0.2.1(react-dom@19.0.0-rc-8f3c0525f9-20240521)(react-server-dom-webpack@19.0.0-rc-8f3c0525f9-20240521)(react@19.0.0-rc-8f3c0525f9-20240521)(vite@5.2.10):
+    resolution: {integrity: sha512-onYyStkkQ6+QGUIt9ac+5Vi4y16mJJaeQgC1NG2VPodUOOZGVwEZ6AXKyatePdapZgRqLah9e8d9COMvI4sNgQ==}
     peerDependencies:
       react: 19.0.0-rc-8f3c0525f9-20240521
       react-dom: 19.0.0-rc-8f3c0525f9-20240521

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -1,4 +1,4 @@
-import { createMiddleware } from "@hattip/adapter-node/native-fetch";
 import { handler } from "../entry-server";
+import { webToNodeHandler } from "@hiogawa/utils-node";
 
-export default createMiddleware((ctx) => handler(ctx.request));
+export default webToNodeHandler(handler);

--- a/src/routes/_action.ts
+++ b/src/routes/_action.ts
@@ -4,10 +4,9 @@ import { redirect, useActionContext } from "@hiogawa/react-server/server";
 import { fakeContacts } from "./_data";
 import { tinyassert } from "@hiogawa/utils";
 
-export async function actionDeleteContact(formData: FormData) {
+export async function actionDeleteContact(id: string) {
   useActionContext().revalidate = true;
-  const data = Object.fromEntries(formData) as any;
-  const contact = await fakeContacts.get(data.id);
+  const contact = await fakeContacts.get(id);
   tinyassert(contact);
   fakeContacts.destroy(contact.id);
 

--- a/src/routes/contacts/[contactId]/edit/page.tsx
+++ b/src/routes/contacts/[contactId]/edit/page.tsx
@@ -24,7 +24,6 @@ export default async function EditContact(props: PageProps) {
       key={contact.id}
       id="contact-form"
     >
-      <input type="hidden" name="id" value={contact.id} />
       <p>
         <span>Name</span>
         <input

--- a/src/routes/contacts/[contactId]/page.tsx
+++ b/src/routes/contacts/[contactId]/page.tsx
@@ -51,9 +51,8 @@ export default async function Contact(props: PageProps) {
           <Link href={`${props.url.pathname}/edit`}>
             <button>Edit</button>
           </Link>
-          {/* TODO: client component for `window.confirm` */}
-          <form action={actionDeleteContact}>
-            <input type="hidden" name="id" value={contact.id} />
+          {/* TODO: client component for `window.confirm`? */}
+          <form action={actionDeleteContact.bind(null, contact.id)}>
             <button type="submit">Delete</button>
           </form>
         </div>
@@ -63,7 +62,7 @@ export default async function Contact(props: PageProps) {
 }
 
 function Favorite(props: { contact: ContactRecord }) {
-  // TODO: optimistic
+  // TODO: useOptimistic?
   const favorite = props.contact.favorite;
   const id = props.contact.id;
 
@@ -77,7 +76,6 @@ function Favorite(props: { contact: ContactRecord }) {
         });
       }}
     >
-      <input type="hidden" name="id" value={props.contact.id} />
       <button
         aria-label={favorite ? "Remove from favorites" : "Add to favorites"}
         name="favorite"


### PR DESCRIPTION
I forgot to update react deps so it was showing peer deps warning. When upgrading it, it somehow had issues with `<input type="hidden" />`, so removed it as that's unnecessary and simply forgotten to be removed in https://github.com/hi-ogawa/react-server-demo-remix-tutorial/pull/8